### PR TITLE
Add server block for gvcmp.us

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -9,9 +9,9 @@ events {
 }
 
 http {
-        gzip on;
-        gzip_comp_level 2;
-        gzip_min_length 512;
+  gzip on;
+  gzip_comp_level 2;
+  gzip_min_length 512;
 
 	server_tokens off;
 
@@ -36,6 +36,20 @@ http {
 		keepalive_timeout 5;
 
 		location / {
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header Host $http_host;
+			proxy_redirect off;
+			proxy_pass http://app_server;
+		}
+	}
+
+	server {
+		listen <%= ENV["PORT"] %>;
+		server_name gvcmp.us;
+		keepalive_timeout 5;
+		
+		location ~ / {
+			rewrite ^/(.*)$ /shortlinks/$1?$args break;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;


### PR DESCRIPTION
Adds a server block for gvcmp.us. This allows nginx to send all
gvcmp.us traffic to the URL we specify **without breaking all
short links**.

This works by taking advantage of our usage of the gvcmp.us domain. It assumes that gvcmp.us is being used for shortlinks only, so it redirects all traffic to our apps `/shortlinks/:id`
route instead of the `/:id`. This will allow us future flexibility with other routes, e.g. `www.givecampus.com/DemoUniverity` instead of `www.givecampus.com/schools/DemoUniversity`.

## Todo
+ [ ] add `get '/shortlinks/:id' => 'shortener/shortened_urls#show'` to the routes.rb f
ile in givecampus/givecampus

## Testing
1. make sure you have nginx installed on your system (`brew install nginx`)
2. create the nginx configuration `cd config && PORT=80 erb nginx.conf.erb > nginx.conf`
3. Start nginx with the following command from this buildpack directory:
`sudo nginx -c ./config/nginx.conf -p ./`
4. update your hosts file to point gvcmp.us and givecampus.com to 0.0.0.0
5. Start the GiveCampus rails server (update ALLOWED_HOSTS to include givecampus.com)
6. curl http://gvcmp.us/gscsc
7. curl http://givecampus.com/gscsc | grep 'Routing Error'
8. curl http://givecampus.com/ (localhost's homepage!)